### PR TITLE
Fix: Workgroup name in the QuickSight CF template & Solution homepage  URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This guidance creates a scalable environment in AWS to prepare genomic, clinical, mutation, expression and imaging data for large-scale analysis and perform interactive queries against a data lake. This solution demonstrates how to 1) build, package, and deploy libraries used for genomics data conversion, 2) provision serverless data ingestion pipelines for multi-modal data preparation and cataloging, 3) visualize and explore clinical data through an interactive interface, and 4) run interactive analytic queries against a multi-modal data lake.
 
 # Setup
-You can setup the solution in your account by clicking the "Deploy sample code on Console" button on the [solution home page](https://aws.amazon.com/solutions/guidance/guidance-for-multi-omics-and-multi-modal-data-integration-and-analysis/).
+You can setup the solution in your account by clicking the "Deploy sample code on Console" button on the [solution home page](https://aws.amazon.com/solutions/guidance/multi-omics-and-multi-modal-data-integration-and-analysis/).
 
 # Customization
 

--- a/multi-omics.code-workspace
+++ b/multi-omics.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/source/GenomicsAnalysisCode/quicksight_cfn.yml
+++ b/source/GenomicsAnalysisCode/quicksight_cfn.yml
@@ -67,8 +67,11 @@ Resources:
       Type: ATHENA
       DataSourceParameters:
         AthenaParameters:
-          WorkGroup: !ImportValue
-            Fn::Sub: '${Project}-ResourcePrefixLowercase'
+          WorkGroup: !Join
+            - "-" 
+            - - !ImportValue
+                  Fn::Sub: '${Project}-ResourcePrefixLowercase'
+              - !Sub ${AWS::Region}
 
   DataSet:
     Type: AWS::QuickSight::DataSet


### PR DESCRIPTION
*Description of changes:*

1.) Fix DataSource workgroup name to include region - otherwise  source/GenomicsAnalysisCode/quicksight_cfn.yml execution  will fail

2.) Update solution homepage URL in  README 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
